### PR TITLE
Upgrade elixir otp

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Setup elixir
       uses: actions/setup-elixir@v1.0.0
       with:
-        elixir-version: 1.9.x
-        otp-version: 22.x
+        elixir-version: 1.9.4
+        otp-version: 22.1
 
     - name: Checkout repository
       uses: actions/checkout@v1


### PR DESCRIPTION
There is a issue when installing OTP and elixir with @actions/setup-elixir, has a version installed but the system reinstall a downgrade.